### PR TITLE
fix: correct Font Awesome class typo for fa-user icon

### DIFF
--- a/assets/js/downloads.js
+++ b/assets/js/downloads.js
@@ -226,7 +226,7 @@ async function loadDeviceDetails(codename) {
             link.href = deviceInfo.maintainerurl;
             link.target = '_blank';
             link.className = 'device-link';
-            link.innerHTML = '<i class="fa fa-user"></i> Reach';
+            link.innerHTML = '<i class="fas fa-user"></i> Reach';
             deviceDetailsLinks.appendChild(link);
         }
         if (deviceInfo.supportgroupurl) {


### PR DESCRIPTION
### What changed
- Fixed a typo where the user icon was using `fa fa-user` instead of the correct `fas fa-user`.


before :

<img width="528" height="192" alt="Screenshot From 2025-09-26 21-59-11" src="https://github.com/user-attachments/assets/bbcf83e8-5d19-449e-8bc8-c6559a899df2" />

after :

<img width="528" height="192" alt="image" src="https://github.com/user-attachments/assets/5bff260a-b34d-4d89-9722-5b8134cc2dd7" />
